### PR TITLE
fetchWeatherをエラーを投げるfetchWeatherに変更し、エラーハンドリングをしました。

### DIFF
--- a/ios-training.xcodeproj/project.pbxproj
+++ b/ios-training.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		690C850628125AA800914156 /* YumemiWeather in Frameworks */ = {isa = PBXBuildFile; productRef = 690C850528125AA800914156 /* YumemiWeather */; };
 		690C850A281272E400914156 /* WeatherType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 690C8509281272E400914156 /* WeatherType.swift */; };
 		690C85102812754A00914156 /* WeatherUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 690C850F2812754A00914156 /* WeatherUseCase.swift */; };
+		690C85182817BD4300914156 /* AlertPresentable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 690C85172817BD4300914156 /* AlertPresentable.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -54,6 +55,7 @@
 		690C84F72812588D00914156 /* ios_trainingUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ios_trainingUITestsLaunchTests.swift; sourceTree = "<group>"; };
 		690C8509281272E400914156 /* WeatherType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeatherType.swift; sourceTree = "<group>"; };
 		690C850F2812754A00914156 /* WeatherUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeatherUseCase.swift; sourceTree = "<group>"; };
+		690C85172817BD4300914156 /* AlertPresentable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertPresentable.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -105,6 +107,7 @@
 		690C84D32812588A00914156 /* ios-training */ = {
 			isa = PBXGroup;
 			children = (
+				690C85172817BD4300914156 /* AlertPresentable.swift */,
 				690C8509281272E400914156 /* WeatherType.swift */,
 				690C850F2812754A00914156 /* WeatherUseCase.swift */,
 				690C850C281273C800914156 /* WeatherDisplay */,
@@ -284,6 +287,7 @@
 				690C85102812754A00914156 /* WeatherUseCase.swift in Sources */,
 				690C84D52812588A00914156 /* AppDelegate.swift in Sources */,
 				690C84D72812588A00914156 /* SceneDelegate.swift in Sources */,
+				690C85182817BD4300914156 /* AlertPresentable.swift in Sources */,
 				690C850A281272E400914156 /* WeatherType.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/ios-training/AlertPresentable.swift
+++ b/ios-training/AlertPresentable.swift
@@ -1,0 +1,25 @@
+//
+//  AlertPresentable.swift
+//  ios-training
+//
+//  Created by 大西 玲音 on 2022/04/26.
+//
+
+import UIKit
+
+protocol AlertPresentable: UIViewController {
+    func presentErrorAlert(title: String)
+}
+
+extension AlertPresentable {
+    
+    func presentErrorAlert(title: String) {
+        let alert = UIAlertController(title: title,
+                                      message: nil,
+                                      preferredStyle: .alert)
+        let alertAction = UIAlertAction(title: "閉じる", style: .default)
+        alert.addAction(alertAction)
+        present(alert, animated: true)
+    }
+    
+}

--- a/ios-training/AlertPresentable.swift
+++ b/ios-training/AlertPresentable.swift
@@ -7,11 +7,11 @@
 
 import UIKit
 
-protocol AlertPresentable: UIViewController {
+protocol AlertPresentable {
     func presentErrorAlert(title: String)
 }
 
-extension AlertPresentable {
+extension AlertPresentable where Self: UIViewController {
     
     func presentErrorAlert(title: String) {
         let alert = UIAlertController(title: title,

--- a/ios-training/WeatherDisplay/WeatherDisplayViewController.swift
+++ b/ios-training/WeatherDisplay/WeatherDisplayViewController.swift
@@ -29,7 +29,7 @@ final class WeatherDisplayViewController: UIViewController {
             weatherImageView.image = UIImage(named: weather.imageName)
             weatherImageView.tintColor = weather.imageColor
         } catch let error as WeatherFetchError {
-            presentErrorAlert(title: "エラーが発生しました。\(error)")
+            presentErrorAlert(title: "エラーが発生しました。\(error.errorText)")
         } catch {
             presentErrorAlert(title: "エラーが発生しました。\(error)")
         }

--- a/ios-training/WeatherDisplay/WeatherDisplayViewController.swift
+++ b/ios-training/WeatherDisplay/WeatherDisplayViewController.swift
@@ -29,7 +29,8 @@ final class WeatherDisplayViewController: UIViewController {
             weatherImageView.image = UIImage(named: weather.imageName)
             weatherImageView.tintColor = weather.imageColor
         } catch let error as WeatherFetchError {
-            presentErrorAlert(title: "エラーが発生しました。\(error.errorText)")
+            let errorDescription = error.errorDescription ?? ""
+            presentErrorAlert(title: "エラーが発生しました。\(errorDescription)")
         } catch {
             presentErrorAlert(title: "予期しないエラーが発生しました。")
         }

--- a/ios-training/WeatherDisplay/WeatherDisplayViewController.swift
+++ b/ios-training/WeatherDisplay/WeatherDisplayViewController.swift
@@ -6,6 +6,7 @@
 //
 
 import UIKit
+import YumemiWeather
 
 final class WeatherDisplayViewController: UIViewController {
     
@@ -30,8 +31,15 @@ final class WeatherDisplayViewController: UIViewController {
             weatherImageView.tintColor = weather.imageColor
         } catch let error as WeatherFetchError {
             presentErrorAlert(title: "エラーが発生しました。\(error.errorText)")
+        } catch let error as YumemiWeatherError {
+            switch error {
+            case .invalidParameterError:
+                presentErrorAlert(title: "無効なパラメーターエラーが発生しました。\(error)")
+            case .unknownError:
+                presentErrorAlert(title: "不明なエラーが発生しました。\(error)")
+            }
         } catch {
-            presentErrorAlert(title: "エラーが発生しました。\(error)")
+            presentErrorAlert(title: "予期しないエラーが発生しました。")
         }
     }
     

--- a/ios-training/WeatherDisplay/WeatherDisplayViewController.swift
+++ b/ios-training/WeatherDisplay/WeatherDisplayViewController.swift
@@ -6,7 +6,6 @@
 //
 
 import UIKit
-import YumemiWeather
 
 final class WeatherDisplayViewController: UIViewController {
     
@@ -31,13 +30,6 @@ final class WeatherDisplayViewController: UIViewController {
             weatherImageView.tintColor = weather.imageColor
         } catch let error as WeatherFetchError {
             presentErrorAlert(title: "エラーが発生しました。\(error.errorText)")
-        } catch let error as YumemiWeatherError {
-            switch error {
-            case .invalidParameterError:
-                presentErrorAlert(title: "無効なパラメーターエラーが発生しました。\(error)")
-            case .unknownError:
-                presentErrorAlert(title: "不明なエラーが発生しました。\(error)")
-            }
         } catch {
             presentErrorAlert(title: "予期しないエラーが発生しました。")
         }

--- a/ios-training/WeatherDisplay/WeatherDisplayViewController.swift
+++ b/ios-training/WeatherDisplay/WeatherDisplayViewController.swift
@@ -8,12 +8,12 @@
 import UIKit
 
 final class WeatherDisplayViewController: UIViewController {
-
+    
     @IBOutlet private weak var weatherImageView: UIImageView!
     @IBOutlet private weak var weatherReloadButton: UIButton!
     
     private let weatherUseCse: WeatherUseCaseProtocol = WeatherUseCase()
-        
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         displayWeather()
@@ -24,14 +24,20 @@ final class WeatherDisplayViewController: UIViewController {
     }
     
     private func displayWeather() {
-        guard let weather = weatherUseCse.fetchWeather() else {
-            fatalError("天気の取得に失敗")
+        do {
+            let weather = try weatherUseCse.fetchWeather()
+            weatherImageView.image = UIImage(named: weather.imageName)
+            weatherImageView.tintColor = weather.imageColor
+        } catch let error as WeatherFetchError {
+            presentErrorAlert(title: "エラーが発生しました。\(error)")
+        } catch {
+            presentErrorAlert(title: "エラーが発生しました。\(error)")
         }
-        weatherImageView.image = UIImage(named: weather.imageName)
-        weatherImageView.tintColor = weather.imageColor
     }
     
 }
+
+extension WeatherDisplayViewController: AlertPresentable { }
 
 private extension WeatherType {
     var imageName: String {

--- a/ios-training/WeatherUseCase.swift
+++ b/ios-training/WeatherUseCase.swift
@@ -14,6 +14,12 @@ protocol WeatherUseCaseProtocol {
 
 enum WeatherFetchError: Error {
     case notFound
+    var errorText: String {
+        switch self {
+        case .notFound:
+            return "天気が見つかりませんでした。"
+        }
+    }
 }
 
 final class WeatherUseCase: WeatherUseCaseProtocol {

--- a/ios-training/WeatherUseCase.swift
+++ b/ios-training/WeatherUseCase.swift
@@ -12,9 +12,9 @@ protocol WeatherUseCaseProtocol {
     func fetchWeather() throws -> WeatherType
 }
 
-enum WeatherFetchError: Error {
+enum WeatherFetchError: LocalizedError {
     case apiError(YumemiWeatherError)
-    var errorText: String {
+    var errorDescription: String? {
         switch self {
         case .apiError(let error):
             switch error {

--- a/ios-training/WeatherUseCase.swift
+++ b/ios-training/WeatherUseCase.swift
@@ -9,15 +9,19 @@ import Foundation
 import YumemiWeather
 
 protocol WeatherUseCaseProtocol {
-    func fetchWeather() -> WeatherType?
+    func fetchWeather() throws -> WeatherType
+}
+
+enum WeatherFetchError: Error {
+    case notFound
 }
 
 final class WeatherUseCase: WeatherUseCaseProtocol {
 
-    func fetchWeather() -> WeatherType?  {
-        let fetchedYumemiWeather = YumemiWeather.fetchWeather()
+    func fetchWeather() throws -> WeatherType {
+        let fetchedYumemiWeather = try YumemiWeather.fetchWeather(at: "tokyo")
         guard let weather = WeatherType(rawValue: fetchedYumemiWeather) else {
-            return nil
+            throw WeatherFetchError.notFound
         }
         return weather
     }

--- a/ios-training/WeatherUseCase.swift
+++ b/ios-training/WeatherUseCase.swift
@@ -33,11 +33,15 @@ enum WeatherFetchError: Error {
 final class WeatherUseCase: WeatherUseCaseProtocol {
 
     func fetchWeather() throws -> WeatherType {
-        let fetchedYumemiWeather = try YumemiWeather.fetchWeather(at: "tokyo")
-        guard let weather = WeatherType(rawValue: fetchedYumemiWeather) else {
-            throw WeatherFetchError.notFound
+        do {
+            let fetchedYumemiWeather = try YumemiWeather.fetchWeather(at: "tokyo")
+            guard let weather = WeatherType(rawValue: fetchedYumemiWeather) else {
+                throw WeatherFetchError.notFound
+            }
+            return weather
+        } catch let error as YumemiWeatherError {
+            throw WeatherFetchError.apiError(error)
         }
-        return weather
     }
     
 }

--- a/ios-training/WeatherUseCase.swift
+++ b/ios-training/WeatherUseCase.swift
@@ -14,10 +14,18 @@ protocol WeatherUseCaseProtocol {
 
 enum WeatherFetchError: Error {
     case notFound
+    case apiError(YumemiWeatherError)
     var errorText: String {
         switch self {
         case .notFound:
             return "天気が見つかりませんでした。"
+        case .apiError(let error):
+            switch error {
+            case .invalidParameterError:
+                return "無効なパラメータエラーが発生しました。"
+            case .unknownError:
+                return "予期しないエラーが発生しました。"
+            }
         }
     }
 }

--- a/ios-training/WeatherUseCase.swift
+++ b/ios-training/WeatherUseCase.swift
@@ -13,12 +13,9 @@ protocol WeatherUseCaseProtocol {
 }
 
 enum WeatherFetchError: Error {
-    case notFound
     case apiError(YumemiWeatherError)
     var errorText: String {
         switch self {
-        case .notFound:
-            return "天気が見つかりませんでした。"
         case .apiError(let error):
             switch error {
             case .invalidParameterError:
@@ -36,7 +33,7 @@ final class WeatherUseCase: WeatherUseCaseProtocol {
         do {
             let fetchedYumemiWeather = try YumemiWeather.fetchWeather(at: "tokyo")
             guard let weather = WeatherType(rawValue: fetchedYumemiWeather) else {
-                throw WeatherFetchError.notFound
+                fatalError("想定外の天気が発生しました。")
             }
             return weather
         } catch let error as YumemiWeatherError {


### PR DESCRIPTION
- 概要
[session3](https://github.com/yumemi-inc/ios-training/blob/main/Documentation/Error.md)
`YumemiWeather`がエラーを投げたときのエラーハンドリングの実装

- やったこと
`YumemiWeather.fetchWeather`をエラーを投げる`YumemiWeather.fetchWeather`に変更し、エラーが発生した時にコントローラー側でアラートを表示する処理を実装しました。
`AlertPresentable protocol`のデフォルト実装でエラーをアラートする処理を実装し、`WeatherDisplayViewController`で呼び出しました。

- 動作
iPhone13
https://user-images.githubusercontent.com/66917548/165420313-2569c3fb-b9a7-4853-b0a8-4d8d2007c277.mov

- 気になること
`AlertPresentable protocol`を使って`WeatherDisplayViewController`から切り離したものの、あまり汎用性がないかもしれないこと。

- 備考
なし

