### PR TITLE
新しい画面を追加し、表示時に天気予報画面に遷移、Closeボタンをタップで新しい画面に戻る処理の実装

### DIFF
--- a/ios-training.xcodeproj/project.pbxproj
+++ b/ios-training.xcodeproj/project.pbxproj
@@ -22,6 +22,8 @@
 		690C851A2818D92300914156 /* Weather.swift in Sources */ = {isa = PBXBuildFile; fileRef = 690C85192818D92300914156 /* Weather.swift */; };
 		690C851C2818DC6700914156 /* WeatherType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 690C851B2818DC6700914156 /* WeatherType.swift */; };
 		690C851E28191D2600914156 /* WeatherRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 690C851D28191D2600914156 /* WeatherRequest.swift */; };
+		690C852028192C7100914156 /* Top.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 690C851F28192C7100914156 /* Top.storyboard */; };
+		690C852228192C7C00914156 /* TopViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 690C852128192C7C00914156 /* TopViewController.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -60,6 +62,8 @@
 		690C85192818D92300914156 /* Weather.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Weather.swift; sourceTree = "<group>"; };
 		690C851B2818DC6700914156 /* WeatherType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WeatherType.swift; sourceTree = "<group>"; };
 		690C851D28191D2600914156 /* WeatherRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeatherRequest.swift; sourceTree = "<group>"; };
+		690C851F28192C7100914156 /* Top.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = Top.storyboard; sourceTree = "<group>"; };
+		690C852128192C7C00914156 /* TopViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopViewController.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -119,6 +123,7 @@
 				690C850C281273C800914156 /* WeatherDisplay */,
 				690C84D42812588A00914156 /* AppDelegate.swift */,
 				690C84D62812588A00914156 /* SceneDelegate.swift */,
+				690C852328192C8100914156 /* Top */,
 				690C84DD2812588D00914156 /* Assets.xcassets */,
 				690C84DF2812588D00914156 /* LaunchScreen.storyboard */,
 				690C84E22812588D00914156 /* Info.plist */,
@@ -150,6 +155,15 @@
 				690C84D82812588A00914156 /* WeatherDisplayViewController.swift */,
 			);
 			path = WeatherDisplay;
+			sourceTree = "<group>";
+		};
+		690C852328192C8100914156 /* Top */ = {
+			isa = PBXGroup;
+			children = (
+				690C851F28192C7100914156 /* Top.storyboard */,
+				690C852128192C7C00914156 /* TopViewController.swift */,
+			);
+			path = Top;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -262,6 +276,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				690C852028192C7100914156 /* Top.storyboard in Resources */,
 				690C84E12812588D00914156 /* LaunchScreen.storyboard in Resources */,
 				690C84DE2812588D00914156 /* Assets.xcassets in Resources */,
 				690C84DC2812588A00914156 /* WeatherDisplay.storyboard in Resources */,
@@ -295,6 +310,7 @@
 				690C851C2818DC6700914156 /* WeatherType.swift in Sources */,
 				690C84D52812588A00914156 /* AppDelegate.swift in Sources */,
 				690C84D72812588A00914156 /* SceneDelegate.swift in Sources */,
+				690C852228192C7C00914156 /* TopViewController.swift in Sources */,
 				690C85182817BD4300914156 /* AlertPresentable.swift in Sources */,
 				690C851A2818D92300914156 /* Weather.swift in Sources */,
 			);
@@ -478,7 +494,7 @@
 				INFOPLIST_FILE = "ios-training/Info.plist";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
-				INFOPLIST_KEY_UIMainStoryboardFile = WeatherDisplay;
+				INFOPLIST_KEY_UIMainStoryboardFile = Top;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -506,7 +522,7 @@
 				INFOPLIST_FILE = "ios-training/Info.plist";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
-				INFOPLIST_KEY_UIMainStoryboardFile = WeatherDisplay;
+				INFOPLIST_KEY_UIMainStoryboardFile = Top;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				LD_RUNPATH_SEARCH_PATHS = (

--- a/ios-training/Info.plist
+++ b/ios-training/Info.plist
@@ -16,7 +16,7 @@
 					<key>UISceneDelegateClassName</key>
 					<string>$(PRODUCT_MODULE_NAME).SceneDelegate</string>
 					<key>UISceneStoryboardFile</key>
-					<string>WeatherDisplay</string>
+					<string>Top</string>
 				</dict>
 			</array>
 		</dict>

--- a/ios-training/Top/Top.storyboard
+++ b/ios-training/Top/Top.storyboard
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Y6W-OH-hqX">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--Top View Controller-->
+        <scene sceneID="s0d-6b-0kx">
+            <objects>
+                <viewController storyboardIdentifier="TopViewController" id="Y6W-OH-hqX" customClass="TopViewController" customModule="ios_training" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="5EZ-qb-Rvc">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <viewLayoutGuide key="safeArea" id="vDu-zF-Fre"/>
+                        <color key="backgroundColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="Ief-a0-LHa" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="139" y="78"/>
+        </scene>
+    </scenes>
+</document>

--- a/ios-training/Top/TopViewController.swift
+++ b/ios-training/Top/TopViewController.swift
@@ -11,13 +11,13 @@ final class TopViewController: UIViewController {
     
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-        presentWeatherDisplayVC()
+        presentWeatherDisplay()
     }
     
-    private func presentWeatherDisplayVC() {
-        let weatherDisplayVC = WeatherDisplayViewController.instantiate()
-        weatherDisplayVC.modalPresentationStyle = .fullScreen
-        present(weatherDisplayVC, animated: true)
+    private func presentWeatherDisplay() {
+        let viewController = WeatherDisplayViewController.instantiate()
+        viewController.modalPresentationStyle = .fullScreen
+        present(viewController, animated: true)
     }
     
 }

--- a/ios-training/Top/TopViewController.swift
+++ b/ios-training/Top/TopViewController.swift
@@ -1,0 +1,23 @@
+//
+//  TopViewController.swift
+//  ios-training
+//
+//  Created by 大西 玲音 on 2022/04/27.
+//
+
+import UIKit
+
+final class TopViewController: UIViewController {
+    
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        presentWeatherDisplayVC()
+    }
+    
+    private func presentWeatherDisplayVC() {
+        let weatherDisplayVC = WeatherDisplayViewController.instantiate()
+        weatherDisplayVC.modalPresentationStyle = .fullScreen
+        present(weatherDisplayVC, animated: true)
+    }
+    
+}

--- a/ios-training/WeatherDisplay/Base.lproj/WeatherDisplay.storyboard
+++ b/ios-training/WeatherDisplay/Base.lproj/WeatherDisplay.storyboard
@@ -12,7 +12,7 @@
         <!--Weather Display View Controller-->
         <scene sceneID="tne-QT-ifu">
             <objects>
-                <viewController id="BYZ-38-t0r" customClass="WeatherDisplayViewController" customModule="ios_training" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="WeatherDisplayViewController" id="BYZ-38-t0r" customClass="WeatherDisplayViewController" customModule="ios_training" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -57,6 +57,9 @@
                                 <rect key="frame" x="125" y="646.5" width="60.5" height="31"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="plain" title="Close"/>
+                                <connections>
+                                    <action selector="closeButtonDidTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="VXI-bn-NUH"/>
+                                </connections>
                             </button>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
@@ -72,6 +75,7 @@
                         </constraints>
                     </view>
                     <connections>
+                        <outlet property="closeButton" destination="NgB-XJ-ful" id="2zR-fu-N5j"/>
                         <outlet property="maxTemperatureLabel" destination="Wuw-9n-AcZ" id="ZV1-be-GWc"/>
                         <outlet property="minTemperatureLabel" destination="XCV-Z2-5Mj" id="AbL-KB-gjQ"/>
                         <outlet property="weatherImageView" destination="jXA-z3-3yz" id="KbI-6Z-9pk"/>

--- a/ios-training/WeatherDisplay/WeatherDisplayViewController.swift
+++ b/ios-training/WeatherDisplay/WeatherDisplayViewController.swift
@@ -47,10 +47,10 @@ final class WeatherDisplayViewController: UIViewController {
     
     static func instantiate() -> WeatherDisplayViewController {
         let weatherDisplayStoryboard = UIStoryboard(name: "WeatherDisplay", bundle: nil)
-        let weatherDisplayVC = weatherDisplayStoryboard.instantiateViewController(
+        let viewController = weatherDisplayStoryboard.instantiateViewController(
             withIdentifier: String(describing: WeatherDisplayViewController.self)
         ) as! WeatherDisplayViewController
-        return weatherDisplayVC
+        return viewController
     }
     
 }

--- a/ios-training/WeatherDisplay/WeatherDisplayViewController.swift
+++ b/ios-training/WeatherDisplay/WeatherDisplayViewController.swift
@@ -13,6 +13,7 @@ final class WeatherDisplayViewController: UIViewController {
     @IBOutlet private weak var maxTemperatureLabel: UILabel!
     @IBOutlet private weak var weatherImageView: UIImageView!
     @IBOutlet private weak var weatherReloadButton: UIButton!
+    @IBOutlet private weak var closeButton: UIButton!
     
     private let weatherUseCse: WeatherUseCaseProtocol = WeatherUseCase()
     
@@ -23,6 +24,10 @@ final class WeatherDisplayViewController: UIViewController {
     
     @IBAction private func weatherReloadButtonDidTapped(_ sender: Any) {
         displayWeather()
+    }
+    
+    @IBAction private func closeButtonDidTapped(_ sender: Any) {
+        dismiss(animated: true)
     }
     
     private func displayWeather() {
@@ -38,6 +43,14 @@ final class WeatherDisplayViewController: UIViewController {
         } catch {
             presentErrorAlert(title: "予期しないエラーが発生しました。")
         }
+    }
+    
+    static func instantiate() -> WeatherDisplayViewController {
+        let weatherDisplayStoryboard = UIStoryboard(name: "WeatherDisplay", bundle: nil)
+        let weatherDisplayVC = weatherDisplayStoryboard.instantiateViewController(
+            withIdentifier: String(describing: WeatherDisplayViewController.self)
+        ) as! WeatherDisplayViewController
+        return weatherDisplayVC
     }
     
 }

--- a/ios-training/WeatherUseCase.swift
+++ b/ios-training/WeatherUseCase.swift
@@ -67,5 +67,5 @@ final class WeatherUseCase: WeatherUseCaseProtocol {
         }
         return weather
     }
-    
+        
 }


### PR DESCRIPTION
- 概要
[session6](https://github.com/yumemi-inc/ios-training/blob/main/Documentation/VC_Lifecycle.md)

- やったこと
新しい画面(`TopViewController`)を追加し、`TopViewController`が表示されると天気予報画面を表示させました。
天気予報画面のCloseボタンをタップで`TopViewController`に戻るようにしました。

- 動作
iPhone13
https://user-images.githubusercontent.com/66917548/165471722-74f0c25c-f33c-4b3e-ab56-dbeb06682035.mov

- 気になること
特にありません

- 備考
特にありません

