### PR TITLE
時間のかかるFetchWeatherメソッドに変更し、処理中にインジケーターを表示させました。

### DIFF
--- a/ios-training.xcodeproj/project.pbxproj
+++ b/ios-training.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		690C851E28191D2600914156 /* WeatherRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 690C851D28191D2600914156 /* WeatherRequest.swift */; };
 		690C852028192C7100914156 /* Top.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 690C851F28192C7100914156 /* Top.storyboard */; };
 		690C852228192C7C00914156 /* TopViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 690C852128192C7C00914156 /* TopViewController.swift */; };
+		695A8615282CAD2900637206 /* DispatchQueue+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 695A8614282CAD2900637206 /* DispatchQueue+Extension.swift */; };
 		69BAA404282B801800238787 /* WeatherUseCaseStub.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69BAA403282B801800238787 /* WeatherUseCaseStub.swift */; };
 /* End PBXBuildFile section */
 
@@ -65,6 +66,7 @@
 		690C851D28191D2600914156 /* WeatherRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeatherRequest.swift; sourceTree = "<group>"; };
 		690C851F28192C7100914156 /* Top.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = Top.storyboard; sourceTree = "<group>"; };
 		690C852128192C7C00914156 /* TopViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopViewController.swift; sourceTree = "<group>"; };
+		695A8614282CAD2900637206 /* DispatchQueue+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DispatchQueue+Extension.swift"; sourceTree = "<group>"; };
 		69BAA403282B801800238787 /* WeatherUseCaseStub.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WeatherUseCaseStub.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -123,6 +125,7 @@
 				690C852328192C8100914156 /* Top */,
 				690C850C281273C800914156 /* WeatherDisplay */,
 				698D10F0282A2E6900E1794C /* Applications */,
+				695A8613282CAD1900637206 /* Extensions */,
 				690C84DD2812588D00914156 /* Assets.xcassets */,
 				690C84DF2812588D00914156 /* LaunchScreen.storyboard */,
 				690C84E22812588D00914156 /* Info.plist */,
@@ -164,6 +167,14 @@
 				690C852128192C7C00914156 /* TopViewController.swift */,
 			);
 			path = Top;
+			sourceTree = "<group>";
+		};
+		695A8613282CAD1900637206 /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				695A8614282CAD2900637206 /* DispatchQueue+Extension.swift */,
+			);
+			path = Extensions;
 			sourceTree = "<group>";
 		};
 		698D10ED282A2BFF00E1794C /* Models */ = {
@@ -340,6 +351,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				690C851E28191D2600914156 /* WeatherRequest.swift in Sources */,
+				695A8615282CAD2900637206 /* DispatchQueue+Extension.swift in Sources */,
 				690C84D92812588A00914156 /* WeatherDisplayViewController.swift in Sources */,
 				690C85102812754A00914156 /* WeatherUseCase.swift in Sources */,
 				690C851C2818DC6700914156 /* WeatherType.swift in Sources */,
@@ -533,6 +545,7 @@
 				INFOPLIST_KEY_UIMainStoryboardFile = Top;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 15.4;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -561,6 +574,7 @@
 				INFOPLIST_KEY_UIMainStoryboardFile = Top;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 15.4;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/ios-training/Extensions/DispatchQueue+Extension.swift
+++ b/ios-training/Extensions/DispatchQueue+Extension.swift
@@ -9,7 +9,7 @@ import Foundation
 
 extension DispatchQueue {
 
-    static func changeToMainThread(handler: @escaping () -> Void) {
+    static func executeMainThread(handler: @escaping () -> Void) {
         if Thread.isMainThread {
             handler()
         } else {

--- a/ios-training/Extensions/DispatchQueue+Extension.swift
+++ b/ios-training/Extensions/DispatchQueue+Extension.swift
@@ -1,0 +1,22 @@
+//
+//  DispatchQueue+Extension.swift
+//  ios-training
+//
+//  Created by 大西 玲音 on 2022/05/12.
+//
+
+import Foundation
+
+extension DispatchQueue {
+
+    static func changeToMainThread(handler: @escaping () -> Void) {
+        if Thread.isMainThread {
+            handler()
+        } else {
+            DispatchQueue.main.async {
+                handler()
+            }
+        }
+    }
+    
+}

--- a/ios-training/UseCases/WeatherUseCase.swift
+++ b/ios-training/UseCases/WeatherUseCase.swift
@@ -53,7 +53,7 @@ final class WeatherUseCase: WeatherUseCaseProtocol {
         }
         let fetchedJson: String
         do {
-            fetchedJson = try YumemiWeather.fetchWeather(jsonString)
+            fetchedJson = try YumemiWeather.syncFetchWeather(jsonString)
         } catch let error as YumemiWeatherError {
             throw error
         }

--- a/ios-training/WeatherDisplay/Base.lproj/WeatherDisplay.storyboard
+++ b/ios-training/WeatherDisplay/Base.lproj/WeatherDisplay.storyboard
@@ -61,14 +61,23 @@
                                     <action selector="closeButtonDidTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="VXI-bn-NUH"/>
                                 </connections>
                             </button>
+                            <activityIndicatorView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" hidesWhenStopped="YES" animating="YES" style="medium" translatesAutoresizingMaskIntoConstraints="NO" id="55p-5u-9kC">
+                                <rect key="frame" x="192" y="586.5" width="30" height="30"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" constant="30" id="Fwz-dy-pr2"/>
+                                    <constraint firstAttribute="width" secondItem="55p-5u-9kC" secondAttribute="height" multiplier="1:1" id="Gp1-4n-zUK"/>
+                                </constraints>
+                            </activityIndicatorView>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
                             <constraint firstItem="VTx-Sj-fUK" firstAttribute="top" secondItem="kuQ-qE-6bY" secondAttribute="bottom" constant="80" id="4nb-7e-lP5"/>
+                            <constraint firstItem="55p-5u-9kC" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="BAl-dd-mNu"/>
                             <constraint firstItem="NgB-XJ-ful" firstAttribute="centerX" secondItem="XCV-Z2-5Mj" secondAttribute="centerX" id="GZK-s6-P8M"/>
                             <constraint firstItem="NgB-XJ-ful" firstAttribute="top" secondItem="kuQ-qE-6bY" secondAttribute="bottom" constant="80" id="Mfd-pc-wDC"/>
                             <constraint firstItem="kuQ-qE-6bY" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="Reb-Bw-8Jd"/>
+                            <constraint firstItem="VTx-Sj-fUK" firstAttribute="top" secondItem="55p-5u-9kC" secondAttribute="bottom" constant="30" id="Y3a-y0-FR4"/>
                             <constraint firstItem="kuQ-qE-6bY" firstAttribute="centerY" secondItem="8bC-Xf-vdC" secondAttribute="centerY" id="a9E-c4-geZ"/>
                             <constraint firstItem="kuQ-qE-6bY" firstAttribute="width" secondItem="8bC-Xf-vdC" secondAttribute="width" multiplier="0.5" id="agZ-eq-1ls"/>
                             <constraint firstItem="VTx-Sj-fUK" firstAttribute="centerX" secondItem="Wuw-9n-AcZ" secondAttribute="centerX" id="s4h-QR-BRc"/>
@@ -76,6 +85,7 @@
                     </view>
                     <connections>
                         <outlet property="closeButton" destination="NgB-XJ-ful" id="2zR-fu-N5j"/>
+                        <outlet property="indicatorView" destination="55p-5u-9kC" id="oA7-Le-sz7"/>
                         <outlet property="maxTemperatureLabel" destination="Wuw-9n-AcZ" id="ZV1-be-GWc"/>
                         <outlet property="minTemperatureLabel" destination="XCV-Z2-5Mj" id="AbL-KB-gjQ"/>
                         <outlet property="weatherImageView" destination="jXA-z3-3yz" id="KbI-6Z-9pk"/>

--- a/ios-training/WeatherDisplay/WeatherDisplayViewController.swift
+++ b/ios-training/WeatherDisplay/WeatherDisplayViewController.swift
@@ -41,7 +41,7 @@ final class WeatherDisplayViewController: UIViewController {
         weatherUseCase.fetchWeather { result in
             do {
                 let weather = try result.get()
-                DispatchQueue.changeToMainThread {
+                DispatchQueue.executeMainThread {
                     self.weatherImageView.image = UIImage(named: weather.imageName)
                     self.weatherImageView.tintColor = weather.imageColor
                     self.minTemperatureLabel.text = String(weather.minTemp)
@@ -51,7 +51,7 @@ final class WeatherDisplayViewController: UIViewController {
             } catch let error as WeatherFetchError {
                 self.removeObserverWillEnterForegroundNotification()
                 let errorDescription = error.errorDescription ?? ""
-                DispatchQueue.changeToMainThread {
+                DispatchQueue.executeMainThread {
                     self.presentErrorAlert(title: "エラーが発生しました。\(errorDescription)") { _ in
                         self.addObserverWillEnterForegroundNotification()
                     }
@@ -59,7 +59,7 @@ final class WeatherDisplayViewController: UIViewController {
                 }
             } catch {
                 self.removeObserverWillEnterForegroundNotification()
-                DispatchQueue.changeToMainThread {
+                DispatchQueue.executeMainThread {
                     self.presentErrorAlert(title: "予期しないエラーが発生しました。") { _ in
                         self.addObserverWillEnterForegroundNotification()
                     }

--- a/ios-training/WeatherDisplay/WeatherDisplayViewController.swift
+++ b/ios-training/WeatherDisplay/WeatherDisplayViewController.swift
@@ -38,10 +38,10 @@ final class WeatherDisplayViewController: UIViewController {
     
     @objc private func displayWeather() {
         indicatorView.startAnimating()
-        DispatchQueue.global().async {
+        weatherUseCase.fetchWeather { result in
             do {
-                let weather = try self.weatherUseCase.fetchWeather()
-                DispatchQueue.main.async {
+                let weather = try result.get()
+                DispatchQueue.changeToMainThread {
                     self.weatherImageView.image = UIImage(named: weather.imageName)
                     self.weatherImageView.tintColor = weather.imageColor
                     self.minTemperatureLabel.text = String(weather.minTemp)
@@ -51,7 +51,7 @@ final class WeatherDisplayViewController: UIViewController {
             } catch let error as WeatherFetchError {
                 self.removeObserverWillEnterForegroundNotification()
                 let errorDescription = error.errorDescription ?? ""
-                DispatchQueue.main.async {
+                DispatchQueue.changeToMainThread {
                     self.presentErrorAlert(title: "エラーが発生しました。\(errorDescription)") { _ in
                         self.addObserverWillEnterForegroundNotification()
                     }
@@ -59,7 +59,7 @@ final class WeatherDisplayViewController: UIViewController {
                 }
             } catch {
                 self.removeObserverWillEnterForegroundNotification()
-                DispatchQueue.main.async {
+                DispatchQueue.changeToMainThread {
                     self.presentErrorAlert(title: "予期しないエラーが発生しました。") { _ in
                         self.addObserverWillEnterForegroundNotification()
                     }

--- a/ios-trainingTests/WeatherUseCaseStub.swift
+++ b/ios-trainingTests/WeatherUseCaseStub.swift
@@ -15,8 +15,8 @@ final class WeatherUseCaseStub: WeatherUseCaseProtocol {
         self.weather = weather
     }
     
-    func fetchWeather() throws -> Weather {
-        weather
+    func fetchWeather(completionHandler: @escaping ResultHandler<Weather>) {
+        completionHandler(.success(weather))
     }
     
 }

--- a/ios-trainingTests/ios_trainingTests.swift
+++ b/ios-trainingTests/ios_trainingTests.swift
@@ -53,6 +53,17 @@ final class ios_trainingTests: XCTestCase {
             weatherUseCase: weatherUseCaseStub
         )
         weatherDisplayViewController.loadViewIfNeeded()
+        waitForAppearExecuted()
+    }
+    
+    private func waitForAppearExecuted() {
+        let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene
+        windowScene?.windows.first?.rootViewController = weatherDisplayViewController
+        let expection = expectation(description: "test")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+            expection.fulfill()
+        }
+        wait(for: [expection], timeout: 3)
     }
     
 }


### PR DESCRIPTION
# 概要
[session9](https://github.com/yumemi-inc/ios-training/blob/main/Documentation/ThreadBlock.md)

# やったこと
YumemiWeatherのFetchメソッドをsyncFetchWeatherに変更し、処理が行われている間にUIActivityIndicatorを表示し、処理が終わると消すようにしました。

# 動作
iPhone13
https://user-images.githubusercontent.com/66917548/167776841-8e3f6032-7254-4532-bfd8-11eb07de64c4.mp4

# 気になること
displayWeatherメソッドのネストがすごく深くなってしまったこと。

# 備考
特にありません
