### PR TITLE
WeatherUseCaseをDelegateからクロージャに書き換えました。

### DIFF
--- a/ios-training/Top/TopViewController.swift
+++ b/ios-training/Top/TopViewController.swift
@@ -17,7 +17,6 @@ final class TopViewController: UIViewController {
     private func presentWeatherDisplay() {
         let weatherUseCase = WeatherUseCase()
         let viewController = WeatherDisplayViewController.instantiate(weatherUseCase: weatherUseCase)
-        weatherUseCase.delegate = viewController
         viewController.modalPresentationStyle = .fullScreen
         present(viewController, animated: true)
     }

--- a/ios-training/UseCases/WeatherUseCase.swift
+++ b/ios-training/UseCases/WeatherUseCase.swift
@@ -9,7 +9,7 @@ import Foundation
 import YumemiWeather
 
 protocol WeatherUseCaseProtocol {
-    func fetchWeather(completion: @escaping ResultHandler<Weather>)
+    func fetchWeather(completion: ResultHandler<Weather>?)
 }
 
 enum WeatherFetchError: LocalizedError {
@@ -43,40 +43,40 @@ typealias ResultHandler<T> = (Result<T, Error>) -> Void
 
 final class WeatherUseCase: WeatherUseCaseProtocol {
     
-    func fetchWeather(completion: @escaping ResultHandler<Weather>) {
+    func fetchWeather(completion: ResultHandler<Weather>?) {
         DispatchQueue.global().async {
             let weatherRequest = WeatherRequest(area: "tokyo", date: Date())
             let encoder = JSONEncoder()
             encoder.dateEncodingStrategy = .iso8601
             guard let requestData = try? encoder.encode(weatherRequest) else {
-                completion(.failure(WeatherFetchError.failedEncoding))
+                completion?(.failure(WeatherFetchError.failedEncoding))
                 return
             }
             guard let jsonString = String(data: requestData, encoding: .utf8) else {
-                completion(.failure(WeatherFetchError.failedConvertDataToJson))
+                completion?(.failure(WeatherFetchError.failedConvertDataToJson))
                 return
             }
             let fetchedJson: String
             do {
                 fetchedJson = try YumemiWeather.syncFetchWeather(jsonString)
             } catch let error as YumemiWeatherError {
-                completion(.failure(error))
+                completion?(.failure(error))
                 return
             } catch {
-                completion(.failure(error))
+                completion?(.failure(error))
                 return
             }
             guard let fetchedJsonData = fetchedJson.data(using: .utf8) else {
-                completion(.failure(WeatherFetchError.failedConvertJsonToData))
+                completion?(.failure(WeatherFetchError.failedConvertJsonToData))
                 return
             }
             let decoder = JSONDecoder()
             decoder.keyDecodingStrategy = .convertFromSnakeCase
             guard let weather = try? decoder.decode(Weather.self, from: fetchedJsonData) else {
-                completion(.failure(WeatherFetchError.failedDecoding))
+                completion?(.failure(WeatherFetchError.failedDecoding))
                 return
             }
-            completion(.success(weather))
+            completion?(.success(weather))
         }
     }
     

--- a/ios-training/UseCases/WeatherUseCase.swift
+++ b/ios-training/UseCases/WeatherUseCase.swift
@@ -8,9 +8,8 @@
 import Foundation
 import YumemiWeather
 
-protocol WeatherUseCaseProtocol: AnyObject {
-    func fetchWeather()
-    var delegate: WeatherUseCaseDelegate? { get }
+protocol WeatherUseCaseProtocol {
+    func fetchWeather(completion: @escaping ResultHandler<Weather>)
 }
 
 enum WeatherFetchError: LocalizedError {
@@ -42,49 +41,42 @@ enum WeatherFetchError: LocalizedError {
 
 typealias ResultHandler<T> = (Result<T, Error>) -> Void
 
-protocol WeatherUseCaseDelegate: AnyObject {
-    func didFetchedWeather(weather: Weather)
-    func didFailedWithError(error: Error)
-}
-
 final class WeatherUseCase: WeatherUseCaseProtocol {
     
-    weak var delegate: WeatherUseCaseDelegate?
-    
-    func fetchWeather() {
+    func fetchWeather(completion: @escaping ResultHandler<Weather>) {
         DispatchQueue.global().async {
             let weatherRequest = WeatherRequest(area: "tokyo", date: Date())
             let encoder = JSONEncoder()
             encoder.dateEncodingStrategy = .iso8601
             guard let requestData = try? encoder.encode(weatherRequest) else {
-                self.delegate?.didFailedWithError(error: WeatherFetchError.failedEncoding)
+                completion(.failure(WeatherFetchError.failedEncoding))
                 return
             }
             guard let jsonString = String(data: requestData, encoding: .utf8) else {
-                self.delegate?.didFailedWithError(error: WeatherFetchError.failedConvertDataToJson)
+                completion(.failure(WeatherFetchError.failedConvertDataToJson))
                 return
             }
             let fetchedJson: String
             do {
                 fetchedJson = try YumemiWeather.syncFetchWeather(jsonString)
             } catch let error as YumemiWeatherError {
-                self.delegate?.didFailedWithError(error: error)
+                completion(.failure(error))
                 return
             } catch {
-                self.delegate?.didFailedWithError(error: error)
+                completion(.failure(error))
                 return
             }
             guard let fetchedJsonData = fetchedJson.data(using: .utf8) else {
-                self.delegate?.didFailedWithError(error: WeatherFetchError.failedConvertJsonToData)
+                completion(.failure(WeatherFetchError.failedConvertJsonToData))
                 return
             }
             let decoder = JSONDecoder()
             decoder.keyDecodingStrategy = .convertFromSnakeCase
             guard let weather = try? decoder.decode(Weather.self, from: fetchedJsonData) else {
-                self.delegate?.didFailedWithError(error: WeatherFetchError.failedDecoding)
+                completion(.failure(WeatherFetchError.failedDecoding))
                 return
             }
-            self.delegate?.didFetchedWeather(weather: weather)
+            completion(.success(weather))
         }
     }
     

--- a/ios-training/WeatherDisplay/WeatherDisplayViewController.swift
+++ b/ios-training/WeatherDisplay/WeatherDisplayViewController.swift
@@ -42,7 +42,35 @@ final class WeatherDisplayViewController: UIViewController {
     
     @objc private func displayWeather() {
         indicatorView.startAnimating()
-        weatherUseCase.fetchWeather()
+        weatherUseCase.fetchWeather { result in
+            do {
+                let weather = try result.get()
+                DispatchQueue.executeMainThread {
+                    self.weatherImageView.image = UIImage(named: weather.imageName)
+                    self.weatherImageView.tintColor = weather.imageColor
+                    self.minTemperatureLabel.text = String(weather.minTemp)
+                    self.maxTemperatureLabel.text = String(weather.maxTemp)
+                    self.indicatorView.stopAnimating()
+                }
+            } catch let error as WeatherFetchError {
+                self.removeObserverWillEnterForegroundNotification()
+                let errorDescription = error.errorDescription ?? ""
+                DispatchQueue.executeMainThread {
+                    self.presentErrorAlert(title: "エラーが発生しました。\(errorDescription)") { _ in
+                        self.addObserverWillEnterForegroundNotification()
+                    }
+                    self.indicatorView.stopAnimating()
+                }
+            } catch {
+                self.removeObserverWillEnterForegroundNotification()
+                DispatchQueue.executeMainThread {
+                    self.presentErrorAlert(title: "予期しないエラーが発生しました。") { _ in
+                        self.addObserverWillEnterForegroundNotification()
+                    }
+                    self.indicatorView.stopAnimating()
+                }
+            }
+        }
     }
     
     static func instantiate(weatherUseCase: WeatherUseCaseProtocol) -> WeatherDisplayViewController {
@@ -69,41 +97,6 @@ final class WeatherDisplayViewController: UIViewController {
             name: UIApplication.willEnterForegroundNotification,
             object: nil
         )
-    }
-    
-}
-
-extension WeatherDisplayViewController: WeatherUseCaseDelegate {
-    
-    func didFetchedWeather(weather: Weather) {
-        DispatchQueue.executeMainThread {
-            self.weatherImageView.image = UIImage(named: weather.imageName)
-            self.weatherImageView.tintColor = weather.imageColor
-            self.minTemperatureLabel.text = String(weather.minTemp)
-            self.maxTemperatureLabel.text = String(weather.maxTemp)
-            self.indicatorView.stopAnimating()
-        }
-    }
-    
-    func didFailedWithError(error: Error) {
-        if let error = error as? WeatherFetchError {
-            self.removeObserverWillEnterForegroundNotification()
-            let errorDescription = error.errorDescription ?? ""
-            DispatchQueue.executeMainThread {
-                self.presentErrorAlert(title: "エラーが発生しました。\(errorDescription)") { _ in
-                    self.addObserverWillEnterForegroundNotification()
-                }
-                self.indicatorView.stopAnimating()
-            }
-        } else {
-            self.removeObserverWillEnterForegroundNotification()
-            DispatchQueue.executeMainThread {
-                self.presentErrorAlert(title: "予期しないエラーが発生しました。") { _ in
-                    self.addObserverWillEnterForegroundNotification()
-                }
-                self.indicatorView.stopAnimating()
-            }
-        }
     }
     
 }

--- a/ios-trainingTests/WeatherUseCaseStub.swift
+++ b/ios-trainingTests/WeatherUseCaseStub.swift
@@ -10,15 +10,14 @@ import Foundation
 
 final class WeatherUseCaseStub: WeatherUseCaseProtocol {
     
-    weak var delegate: WeatherUseCaseDelegate?
     let weather: Weather
     
     init(weather: Weather) {
         self.weather = weather
     }
     
-    func fetchWeather() {
-        delegate?.didFetchedWeather(weather: weather)
+    func fetchWeather(completion: ResultHandler<Weather>?) {
+        completion?(.success(weather))
     }
 
 }

--- a/ios-trainingTests/ios_trainingTests.swift
+++ b/ios-trainingTests/ios_trainingTests.swift
@@ -52,7 +52,6 @@ final class ios_trainingTests: XCTestCase {
         weatherDisplayViewController = WeatherDisplayViewController.instantiate(
             weatherUseCase: weatherUseCaseStub
         )
-        weatherUseCaseStub.delegate = weatherDisplayViewController
         weatherDisplayViewController.loadViewIfNeeded()
         waitForAppearExecuted()
     }


### PR DESCRIPTION
# 概要
[session11](https://github.com/yumemi-inc/ios-training/blob/main/Documentation/Closure.md)

# やったこと
`WeatherUseCase`をDelegateで実装していたものをクロージャを用いて書き換えました。
`WeatherDisplayViewController`で`deinit`メソッドをかき、このメソッドが呼ばれていることを確認しました。

# 動作
iPhone13 Pro
https://user-images.githubusercontent.com/66917548/168194552-56863b2f-bf82-4a0b-b29f-7da16d1b5e75.mp4

# 気になること
特にありません

# 備考
> ぜひ関数型引数はOptional型、非Optional型の両方を実装し、その違いを確認してみましょう。

オプショナル型にすると、`@escaping`が不要になりました。オプショナル型にすると暗黙的に`@escaping`属性になるようです。
